### PR TITLE
中の人が居ないアイコンに関する挙動修正

### DIFF
--- a/index.css
+++ b/index.css
@@ -123,6 +123,9 @@ div.graph .fill{
     color: #43211a;
     text-decoration: none;
 }
+.members a.icon.disabled {
+	cursor: default;
+}
 .members a.icon img {
     margin: 0;
     padding: 0;
@@ -141,6 +144,9 @@ div.graph .fill{
 }
 .members a.icon img:hover {
     box-shadow: 0 3px 10px 5px rgba(255,255,255,0.5);
+}
+.members a.icon.disabled img:hover {
+    box-shadow: none;
 }
 
 .member{

--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@
 	
 	window.addEventListener('DOMContentLoaded', function(eve){
 		loadingTimerCallback();
+		
+		$(document).on('click', 'a.disabled', disabledLinkEvent);
+		
 		$.ajax({
 			url: 'api.php',
 			dataType: 'json',
@@ -75,7 +78,11 @@
 				.append($('<ul class="member"></ul>')
 					.append($('<li class="check"></li>').addClass(checkName))
 					.append($('<li class="icon"></li>')
-						.append($('<a target="_blank" class="icon"></a>').attr('href',profileUri)
+						.append($('<a class="icon"></a>').attr({
+								'href': profileUri,
+								'target': (isExist) ? '_blank' : '_self',
+							})
+							.addClass(isExist ? '' : 'disabled')
 							.append($('<img>').attr({
 									'src': iconSrc,
 									'alt': altName,
@@ -86,6 +93,10 @@
 		}));
 		
 		$('.members').append($fragment);
+	}
+	
+	function disabledLinkEvent(eve){
+		return false;
 	}
 	
 	function htmlSpecialChars(list){


### PR DESCRIPTION
中の人が居ないアイコンにカーソルを合わせようとしたり、クリックしようとした時にその挙動を無視するようにしました。(日本語の不自由さを感じるが伝われ)

通常のアイコンにマウスカーソルを合わせると、アイコンが光ってリンクになります。
![1](https://cloud.githubusercontent.com/assets/9548212/12305756/a9fb819a-ba79-11e5-98a3-7d11794ae610.png)

今回、中の人が居ないアイコンに関しては、この挙動を行わず、アイコンを光らせずにリンクもさせないようにしました。
![2](https://cloud.githubusercontent.com/assets/9548212/12305751/a8762f46-ba79-11e5-8a79-11014ef664c1.png)