### PR TITLE
正規表現の修正

### DIFF
--- a/user_information.php
+++ b/user_information.php
@@ -20,7 +20,7 @@ if( isset( $_GET["id"] ) && is_numeric( $_GET["id"] ) ) {
     curl_close($ch);
     
     if($httpCode === 200){
-        $pattern_name = '#<title>(.*?) \(@[a-z0-9_]{1,15}\) さんはTwitterを使ってます</title>#i';
+        $pattern_name = '#<title>(.*?) \(@[a-z0-9_]{1,15}\) [^<]+</title>#i';
         $pattern_profile_image_url_https = '<img class="photo" src="(.+?)".+?>';
         $pattern_screen_name = '#<span class="nickname">@([a-z0-9_]{1,15})</span>#';
         // name


### PR DESCRIPTION
https://twitter.com/intent/user?user_id=○○
の戻り値が、たまに日本語ではなく英語で帰ってくるようです。

既存の正規表現だと、英語で帰ってきた時に「**さんはTwitterを使ってます**」という日本語部分がHITせずに、それでエラーを吐いていたようです。
同様箇所の英語表記版である「**on Twitter**」っていう、パターンを厳密に取ろうと思いましたが、面倒くさいので正規表現を緩くすることでこれを解決しました